### PR TITLE
chore(ci): slightly shorten release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,17 @@ jobs:
         uses: ComunidadAylas/PackSquash-action@v3
         with:
           artifact_name: datapack-raw
-          force_include_files: icon.png
+          force_include_files: |
+            icon.png
+            LICENSE.txt
+            README.md
+            CHANGELOG.md
       - name: Download datapack-raw
         uses: actions/download-artifact@v3
         with:
           name: datapack-raw
-      - name: Finish datapack
-        run: |
-          mv pack.zip No-Lag.zip
-          zip -u No-Lag.zip LICENSE.txt README.md CHANGELOG.md
+      - name: Rename datapack
+        run: mv pack.zip No-Lag.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Hi! :wave: I just noticed that this repository uses the PackSquash GitHub Action, so I decided to take a look at it. I was pleased with what I saw: the way it combines several pack authoring tools in workflows is inspiring!

However, I noticed one small thing I could help improve: currently, the release workflow lets PackSquash create a ZIP with the pack and then adds three files that are checked into the repository.

However, this is unnecessarily verbose: PackSquash has a feature to force it to include files in the ZIP that it would otherwise skip. This feature is already being used for the "icon.png" file, so let's leverage it for the licensing and metadata files as well.